### PR TITLE
fix [#55]: Fix ESLint package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "eslint": "^8.57.0",
-    "@next/eslint-config-nextjs": "^14.2.0"
+    "eslint-config-next": "^14.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- Fix ESLint package name from @next/eslint-config-nextjs to eslint-config-next
- Closes #55