### PR TITLE
chore [#57]: Disable ESLint during build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- Disable ESLint during build to fix deployment errors
- Closes #57