### PR TITLE
feat: NASA APIs Integration - APOD & Mars Rover Photos 🌌

### DIFF
--- a/src/app/api/nasa/apod/route.ts
+++ b/src/app/api/nasa/apod/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const NASA_API_KEY = process.env.NASA_API_KEY || 'DEMO_KEY';
+const APOD_API_URL = 'https://api.nasa.gov/planetary/apod';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const date = searchParams.get('date');
+  
+  try {
+    let url = `${APOD_API_URL}?api_key=${NASA_API_KEY}`;
+    
+    if (date) {
+      url += `&date=${date}`;
+    }
+
+    const response = await fetch(url, {
+      next: { revalidate: 3600 }, // Cache for 1 hour
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: 'Failed to fetch NASA APOD' },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error fetching NASA APOD:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/nasa/mars/route.ts
+++ b/src/app/api/nasa/mars/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const NASA_API_KEY = process.env.NASA_API_KEY || 'DEMO_KEY';
+const MARS_API_URL = 'https://api.nasa.gov/mars-photos/api/v1/rovers/curiosity/photos';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const sol = searchParams.get('sol') || '1000';
+  const page = searchParams.get('page') || '1';
+  
+  try {
+    const url = `${MARS_API_URL}?sol=${sol}&page=${page}&api_key=${NASA_API_KEY}`;
+
+    const response = await fetch(url, {
+      next: { revalidate: 3600 }, // Cache for 1 hour
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: 'Failed to fetch Mars rover photos' },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error fetching Mars photos:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/nasa/page.tsx
+++ b/src/app/nasa/page.tsx
@@ -1,0 +1,41 @@
+import NASAApodGallery from '@/components/NASAApodGallery';
+import MarsPhotosGallery from '@/components/MarsPhotosGallery';
+
+export const metadata = {
+  title: 'NASA Gallery | Starfleet Fleet Monitoring',
+  description: 'Explore NASA astronomy pictures and Mars rover photos',
+};
+
+export default function NASAPage() {
+  return (
+    <div className="min-h-screen bg-gray-900">
+      <div className="container mx-auto px-4 py-8">
+        <div className="mb-8">
+          <h1 className="text-4xl font-bold text-white mb-2">
+            NASA Space Exploration 🌌
+          </h1>
+          <p className="text-gray-400">
+            Explore the cosmos with NASA\'s public APIs
+          </p>
+        </div>
+
+        <div className="mb-12">
+          <h2 className="text-2xl font-bold text-white mb-4 flex items-center gap-2">
+            <span className="text-2xl">🌟</span> Astronomy Picture of the Day
+          </h2>
+          <NASAApodGallery />
+        </div>
+
+        <div>
+          <h2 className="text-2xl font-bold text-white mb-4 flex items-center gap-2">
+            <span className="text-2xl">🔴</span> Mars Rover Photos
+          </h2>
+          <p className="text-gray-400 mb-6">
+            Explore photos from NASA\'s Curiosity rover on Mars
+          </p>
+          <MarsPhotosGallery />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import { ShipCard } from '@/components';
 import { mockStarships } from '@/data';
 import NewsWidget from '@/components/NewsWidget';
+import NASAApodWidget from '@/components/NASAApodWidget';
 import Link from 'next/link';
 import SearchFilterBar from '@/components/SearchFilterBar';
 import ShipDetailModal from '@/components/ShipDetailModal';
@@ -74,6 +75,12 @@ export default function Home() {
           <div className="flex items-center gap-3">
             <ThemeToggle />
             <Link
+              href="/nasa"
+              className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors text-sm"
+            >
+              NASA 🌌
+            </Link>
+            <Link
               href="/news"
               className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm"
             >
@@ -131,7 +138,8 @@ export default function Home() {
           )}
         </div>
         <div className="lg:col-span-1">
-          <div className="sticky top-4">
+          <div className="sticky top-4 space-y-4">
+            <NASAApodWidget />
             <NewsWidget />
           </div>
         </div>

--- a/src/components/MarsPhotosGallery.tsx
+++ b/src/components/MarsPhotosGallery.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Image from 'next/image';
+import { MarsPhoto, MarsPhotosResponse } from '@/types/nasa';
+
+const SOLS = [1000, 500, 100, 50, 10];
+
+export default function MarsPhotosGallery() {
+  const [photos, setPhotos] = useState<MarsPhoto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedSol, setSelectedSol] = useState('1000');
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    fetchPhotos();
+  }, [selectedSol, page]);
+
+  const fetchPhotos = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/nasa/mars?sol=${selectedSol}&page=${page}`);
+      if (!response.ok) {
+        throw new Error('Failed to fetch Mars photos');
+      }
+      const data: MarsPhotosResponse = await response.json();
+      setPhotos(data.photos || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSolChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedSol(e.target.value);
+    setPage(1);
+  };
+
+  if (loading && photos.length === 0) {
+    return (
+      <div className="flex justify-center items-center py-20">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-red-500"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-20">
+        <p className="text-red-500 mb-4">{error}</p>
+        <button
+          onClick={fetchPhotos}
+          className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+        >
+          Try Again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex gap-4 mb-6">
+        <select
+          value={selectedSol}
+          onChange={handleSolChange}
+          className="px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white focus:outline-none focus:border-red-500"
+        >
+          {SOLS.map(sol => (
+            <option key={sol} value={sol}>
+              Sol {sol} ({new Date(Date.now() - sol * 24 * 60 * 60 * 1000).toLocaleDateString()})
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {photos.length === 0 ? (
+        <p className="text-center text-gray-400 py-12">No photos found for this sol.</p>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+            {photos.map((photo) => (
+              <div key={photo.id} className="bg-gray-800 rounded-lg overflow-hidden border border-gray-700 hover:border-red-500 transition-colors">
+                <div className="relative h-48 w-full">
+                  <Image
+                    src={photo.img_src}
+                    alt={`Mars Photo ${photo.id}`}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 25vw"
+                  />
+                </div>
+                <div className="p-3">
+                  <p className="text-white text-sm font-semibold">
+                    {photo.camera.full_name}
+                  </p>
+                  <p className="text-gray-400 text-xs">
+                    {photo.earth_date}
+                  </p>
+                  <p className="text-gray-500 text-xs mt-1">
+                    Rover: {photo.rover.name}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="flex justify-center items-center gap-4 mt-8">
+            <button
+              onClick={() => setPage(Math.max(1, page - 1))}
+              disabled={page === 1}
+              className="px-4 py-2 bg-gray-700 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-600 transition-colors"
+            >
+              Previous
+            </button>
+            <span className="text-gray-400">Page {page}</span>
+            <button
+              onClick={() => setPage(page + 1)}
+              disabled={photos.length < 25}
+              className="px-4 py-2 bg-gray-700 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-600 transition-colors"
+            >
+              Next
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/NASAApodGallery.tsx
+++ b/src/components/NASAApodGallery.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Image from 'next/image';
+import { NASAApod } from '@/types/nasa';
+
+export default function NASAApodGallery() {
+  const [apod, setApod] = useState<NASAApod | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedDate, setSelectedDate] = useState<string>('');
+
+  useEffect(() => {
+    fetchApod();
+  }, []);
+
+  const fetchApod = async (date?: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = date ? `/api/nasa/apod?date=${date}` : '/api/nasa/apod';
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error('Failed to fetch APOD');
+      }
+      const data = await response.json();
+      setApod(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedDate(e.target.value);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (selectedDate) {
+      fetchApod(selectedDate);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center py-20">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-20">
+        <p className="text-red-500 mb-4">{error}</p>
+        <button
+          onClick={() => fetchApod()}
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+        >
+          Try Again
+        </button>
+      </div>
+    );
+  }
+
+  if (!apod) return null;
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit} className="mb-6 flex gap-4">
+        <input
+          type="date"
+          value={selectedDate}
+          onChange={handleDateChange}
+          max={new Date().toISOString().split('T')[0]}
+          className="px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white focus:outline-none focus:border-blue-500"
+        />
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+        >
+          Search
+        </button>
+        <button
+          type="button"
+          onClick={() => { setSelectedDate(''); fetchApod(); }}
+          className="px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600 transition-colors"
+        >
+          Today
+        </button>
+      </form>
+
+      <div className="bg-gray-800 rounded-xl overflow-hidden border border-gray-700">
+        {apod.media_type === 'image' ? (
+          <div className="relative h-64 md:h-96 w-full">
+            <Image
+              src={apod.url}
+              alt={apod.title}
+              fill
+              className="object-cover"
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              priority
+            />
+          </div>
+        ) : (
+          <div className="w-full h-64 md:h-96 flex items-center justify-center bg-gray-700">
+            <iframe
+              src={apod.url}
+              title={apod.title}
+              className="w-full h-full"
+              allowFullScreen
+            />
+          </div>
+        )}
+        
+        <div className="p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h1 className="text-2xl md:text-3xl font-bold text-white">
+              {apod.title}
+            </h1>
+            <span className="text-gray-400 text-sm">
+              {apod.date}
+            </span>
+          </div>
+          
+          {apod.copyright && (
+            <p className="text-gray-500 text-sm mb-4">
+              © {apod.copyright}
+            </p>
+          )}
+          
+          <p className="text-gray-300 leading-relaxed">
+            {apod.explanation}
+          </p>
+          
+          {apod.hdurl && apod.media_type === 'image' && (
+            <a
+              href={apod.hdurl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              View HD Version
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NASAApodWidget.tsx
+++ b/src/components/NASAApodWidget.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Image from 'next/image';
+import { NASAApod } from '@/types/nasa';
+
+export default function NASAApodWidget() {
+  const [apod, setApod] = useState<NASAApod | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchApod = async () => {
+      try {
+        const response = await fetch('/api/nasa/apod');
+        if (!response.ok) {
+          throw new Error('Failed to fetch APOD');
+        }
+        const data = await response.json();
+        setApod(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'An error occurred');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchApod();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="bg-gray-800 rounded-lg p-4 border border-gray-700">
+        <div className="animate-pulse space-y-3">
+          <div className="h-32 bg-gray-700 rounded"></div>
+          <div className="h-4 bg-gray-700 rounded w-3/4"></div>
+          <div className="h-3 bg-gray-700 rounded w-1/2"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !apod) {
+    return (
+      <div className="bg-gray-800 rounded-lg p-4 border border-gray-700">
+        <p className="text-gray-400 text-sm">Unable to load NASA APOD</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-gray-800 rounded-lg overflow-hidden border border-gray-700">
+      <div className="relative h-32 w-full">
+        {apod.media_type === 'image' ? (
+          <Image
+            src={apod.url}
+            alt={apod.title}
+            fill
+            className="object-cover"
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center bg-gray-700">
+            <span className="text-gray-400">Video</span>
+          </div>
+        )}
+      </div>
+      <div className="p-3">
+        <h3 className="text-white font-semibold text-sm line-clamp-2 mb-1">
+          {apod.title}
+        </h3>
+        <p className="text-gray-400 text-xs">
+          {apod.date}
+        </p>
+        {apod.copyright && (
+          <p className="text-gray-500 text-xs mt-1">
+            © {apod.copyright}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/types/nasa.ts
+++ b/src/types/nasa.ts
@@ -1,0 +1,34 @@
+export interface NASAApod {
+  date: string;
+  explanation: string;
+  hdurl: string;
+  media_type: string;
+  service_version: string;
+  title: string;
+  url: string;
+  copyright?: string;
+}
+
+export interface MarsPhoto {
+  id: number;
+  sol: number;
+  camera: {
+    id: number;
+    name: string;
+    rover_id: number;
+    full_name: string;
+  };
+  img_src: string;
+  earth_date: string;
+  rover: {
+    id: number;
+    name: string;
+    landing_date: string;
+    launch_date: string;
+    status: string;
+  };
+}
+
+export interface MarsPhotosResponse {
+  photos: MarsPhoto[];
+}


### PR DESCRIPTION
## Summary
- Integrate NASA public APIs for real space data
- Add Astronomy Picture of the Day (APOD) widget
- Add Mars Rover Photos gallery
- Create NASA page with full galleries

## NASA APIs Integrated
1. **APOD (Astronomy Picture of the Day)**
   - API: `https://api.nasa.gov/planetary/apod`
   - Uses DEMO_KEY (users can get their own key)

2. **Mars Rover Photos**
   - API: `https://api.nasa.gov/mars-photos/api/v1/rovers/curiosity/photos`
   - Filter by sol (Martian day)

## Changes
- Added API routes:
  - `/api/nasa/apod` - Astronomy Picture of the Day
  - `/api/nasa/mars` - Mars Rover Photos
- Added components:
  - `NASAApodWidget` - Mini widget for dashboard
  - `NASAApodGallery` - Full APOD gallery with date picker
  - `MarsPhotosGallery` - Mars rover photos with sol filter
- Added page:
  - `/nasa` - Full NASA exploration page
- Updated main dashboard with NASA button and APOD widget

## Features
- Daily astronomy picture with explanation
- Mars rover photos from Curiosity
- Date picker for APOD
- Sol selector for Mars photos
- Pagination for Mars gallery